### PR TITLE
Add Oracle database connection with CRUD and multi-tenant support

### DIFF
--- a/src/main/java/us/com/rclabs/app/multitenant/MultiTenantConfig.java
+++ b/src/main/java/us/com/rclabs/app/multitenant/MultiTenantConfig.java
@@ -1,0 +1,85 @@
+package us.com.rclabs.app.multitenant;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class MultiTenantConfig {
+
+    @Autowired
+    private Environment environment;
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource")
+    public DataSource dataSource() {
+        return new org.apache.tomcat.jdbc.pool.DataSource();
+    }
+
+    @Bean
+    public DataSource multiTenantDataSource() {
+        AbstractRoutingDataSource dataSource = new AbstractRoutingDataSource() {
+            @Override
+            protected Object determineCurrentLookupKey() {
+                return TenantContext.getCurrentTenant();
+            }
+        };
+
+        Map<Object, Object> targetDataSources = new HashMap<>();
+        targetDataSources.put("tenant1", createDataSource("tenant1"));
+        targetDataSources.put("tenant2", createDataSource("tenant2"));
+
+        dataSource.setTargetDataSources(targetDataSources);
+        dataSource.setDefaultTargetDataSource(createDataSource("default"));
+
+        return dataSource;
+    }
+
+    private DataSource createDataSource(String tenant) {
+        org.apache.tomcat.jdbc.pool.DataSource dataSource = new org.apache.tomcat.jdbc.pool.DataSource();
+        dataSource.setDriverClassName(environment.getProperty("spring.datasource.driver-class-name"));
+        dataSource.setUrl(environment.getProperty("spring.datasource.url").replace("default", tenant));
+        dataSource.setUsername(environment.getProperty("spring.datasource.username"));
+        dataSource.setPassword(environment.getProperty("spring.datasource.password"));
+        return dataSource;
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+        LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
+        em.setDataSource(multiTenantDataSource());
+        em.setPackagesToScan(new String[]{"us.com.rclabs.app"});
+
+        HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+        em.setJpaVendorAdapter(vendorAdapter);
+        em.setJpaProperties(hibernateProperties());
+
+        return em;
+    }
+
+    private Map<String, Object> hibernateProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("hibernate.dialect", environment.getProperty("spring.jpa.properties.hibernate.dialect"));
+        properties.put("hibernate.show_sql", environment.getProperty("spring.jpa.show-sql"));
+        properties.put("hibernate.hbm2ddl.auto", environment.getProperty("spring.jpa.hibernate.ddl-auto"));
+        return properties;
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+        JpaTransactionManager transactionManager = new JpaTransactionManager();
+        transactionManager.setEntityManagerFactory(entityManagerFactory().getObject());
+        return transactionManager;
+    }
+}

--- a/src/main/java/us/com/rclabs/app/parameters/Parameter.java
+++ b/src/main/java/us/com/rclabs/app/parameters/Parameter.java
@@ -1,0 +1,42 @@
+package us.com.rclabs.app.parameters;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Parameter {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String value;
+
+    // Getters and Setters
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/us/com/rclabs/app/parameters/ParameterRepository.java
+++ b/src/main/java/us/com/rclabs/app/parameters/ParameterRepository.java
@@ -1,0 +1,8 @@
+package us.com.rclabs.app.parameters;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ParameterRepository extends JpaRepository<Parameter, Long> {
+}

--- a/src/main/java/us/com/rclabs/app/parameters/ParameterService.java
+++ b/src/main/java/us/com/rclabs/app/parameters/ParameterService.java
@@ -1,0 +1,43 @@
+package us.com.rclabs.app.parameters;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ParameterService {
+
+    @Autowired
+    private ParameterRepository parameterRepository;
+
+    public Parameter createParameter(Parameter parameter) {
+        return parameterRepository.save(parameter);
+    }
+
+    public Optional<Parameter> getParameterById(Long id) {
+        return parameterRepository.findById(id);
+    }
+
+    public List<Parameter> getAllParameters() {
+        return parameterRepository.findAll();
+    }
+
+    public Parameter updateParameter(Long id, Parameter parameterDetails) {
+        Parameter parameter = parameterRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Parameter not found with id " + id));
+
+        parameter.setName(parameterDetails.getName());
+        parameter.setValue(parameterDetails.getValue());
+
+        return parameterRepository.save(parameter);
+    }
+
+    public void deleteParameter(Long id) {
+        Parameter parameter = parameterRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Parameter not found with id " + id));
+
+        parameterRepository.delete(parameter);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,18 @@ spring:
   output:
     ansi:
       enabled: ALWAYS
+  datasource:
+    url: jdbc:oracle:thin:@//localhost:1521/ORCL
+    username: ${oracle.username}
+    password: ${oracle.password}
+    driver-class-name: oracle.jdbc.OracleDriver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.Oracle12cDialect
 oracle:
   username: user
   password: pass

--- a/src/test/java/us/com/rclabs/app/DatabaseConnectionTest.java
+++ b/src/test/java/us/com/rclabs/app/DatabaseConnectionTest.java
@@ -1,0 +1,21 @@
+package us.com.rclabs.app;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+public class DatabaseConnectionTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    public void testConnection() {
+        assertNotNull(jdbcTemplate, "JdbcTemplate should not be null");
+        jdbcTemplate.execute("SELECT 1 FROM DUAL");
+    }
+}


### PR DESCRIPTION
Fixes #1

Add Oracle database connection and CRUD operations for parameters.

* **Database Configuration**
  - Modify `src/main/resources/application.yml` to include Oracle database connection configuration and JPA properties.

* **Parameter Service**
  - Add `src/main/java/us/com/rclabs/app/parameters/ParameterService.java` to implement CRUD operations for parameters.
  - Add `src/main/java/us/com/rclabs/app/parameters/ParameterRepository.java` to create a repository interface for parameters.
  - Add `src/main/java/us/com/rclabs/app/parameters/Parameter.java` to create an entity class for parameters.

* **Database Connection Test**
  - Add `src/test/java/us/com/rclabs/app/DatabaseConnectionTest.java` to verify the Oracle database connection.

* **Multi-Tenant Configuration**
  - Add `src/main/java/us/com/rclabs/app/multitenant/MultiTenantConfig.java` to implement multi-tenant support for Oracle database connections.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zlovtnik/jja/pull/3?shareId=e0898ed7-b9f4-444a-91cf-f754f7ca4663).